### PR TITLE
fix(actions type): merge type when use mutiple models and some action is derived from plugins

### DIFF
--- a/.changeset/swift-masks-film.md
+++ b/.changeset/swift-masks-film.md
@@ -1,0 +1,5 @@
+---
+"@modern-js-reduck/store": patch
+---
+
+fix: merge actions bug when use mutiple models

--- a/packages/store/src/types/model.ts
+++ b/packages/store/src/types/model.ts
@@ -108,9 +108,15 @@ type GetModelsState<Models extends Model[]> = UnionToIntersection<
   MountedModel<Models[number]>['state']
 >;
 
-type GetModelsAction<Models extends Model[]> = UnionToIntersection<
-  MountedModel<Models[number]>['actions']
->;
+type GetModelsAction<Models extends Model[]> = Models extends [
+  infer Head,
+  ...infer Tail
+]
+  ? (Head extends Model
+      ? UnionToIntersection<Merge<GetActions<Head>, 'actions'>['actions']>
+      : Record<string, unknown>) &
+      (Tail extends Model[] ? GetModelsAction<Tail> : Record<string, unknown>)
+  : Record<string, unknown>;
 
 type GetModelsStateTuple<
   Models extends ModelType[],


### PR DESCRIPTION
fix: #30 and solved action type merge bug that some actions type are from plugins (auto-actions、effects).