### PR TITLE
feat: support useModel only accept actions selector (close: #28)

### DIFF
--- a/packages/react/src/__test__/useModel.test.tsx
+++ b/packages/react/src/__test__/useModel.test.tsx
@@ -1,0 +1,84 @@
+import { model } from '@modern-js-reduck/store';
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { useModel, Provider } from '..';
+
+const modelA = model('modelA').define({
+  state: {
+    a: 1,
+  },
+  actions: {
+    incA(state) {
+      return {
+        a: state.a + 1,
+      };
+    },
+  },
+});
+const modelB = model('modelB').define({
+  state: {
+    b: 10,
+  },
+  actions: {
+    incB(state) {
+      return {
+        b: state.b + 1,
+      };
+    },
+  },
+});
+
+describe('test useModel', () => {
+  test('useModel with actionSelectors', () => {
+    const App = () => {
+      const [state, actions] = useModel(
+        modelA,
+        modelB,
+        undefined,
+        (actionsA, actionsB) => {
+          return {
+            ...actionsA,
+            ...actionsB,
+            incAB() {
+              actionsA.incA();
+              actionsB.incB();
+            },
+          };
+        },
+      );
+
+      return (
+        <>
+          <div>{state.a}</div>
+          <div>{state.b}</div>
+          <button type="button" onClick={() => actions.incA()}>
+            incA
+          </button>
+          <button type="button" onClick={() => actions.incB()}>
+            incB
+          </button>
+          <button type="button" onClick={() => actions.incAB()}>
+            incAB
+          </button>
+        </>
+      );
+    };
+
+    const result = render(
+      <Provider>
+        <App />
+      </Provider>,
+    );
+
+    expect(result.getByText(1)).toBeInTheDocument();
+    expect(result.getByText(10)).toBeInTheDocument();
+
+    fireEvent.click(result.getByText('incA'));
+    fireEvent.click(result.getByText('incB'));
+    expect(result.getByText(2)).toBeInTheDocument();
+    expect(result.getByText(11)).toBeInTheDocument();
+    fireEvent.click(result.getByText('incAB'));
+    expect(result.getByText(3)).toBeInTheDocument();
+    expect(result.getByText(12)).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/batchManager.ts
+++ b/packages/react/src/batchManager.ts
@@ -2,7 +2,7 @@ import { Store } from '@modern-js-reduck/store';
 import { unstable_batchedUpdates } from 'react-dom';
 import { Model } from '@modern-js-reduck/store/dist/types/types';
 
-const isModel = (model: Model | any) => Boolean(model._name);
+const isModel = (model: Model | any) => Boolean(model?._name);
 
 const combineSubscribe = (
   store: Store,

--- a/packages/store/src/model/model.ts
+++ b/packages/store/src/model/model.ts
@@ -106,7 +106,8 @@ const model: ModelFn = name => ({
   },
 });
 
-export const getModelInitializer = (_model: Model) => _model[initializerSymbol];
+export const getModelInitializer = (_model: Model) =>
+  _model?.[initializerSymbol];
 
 export const isModel = (_model: any): _model is Model =>
   Boolean(getModelInitializer(_model));

--- a/packages/store/src/model/useModel.ts
+++ b/packages/store/src/model/useModel.ts
@@ -43,22 +43,16 @@ function createUseModel(context: Context): UseModel {
 const parseModelParams = (context: Context, _models: any) => {
   const models = Array.isArray(_models) ? _models : [_models];
   const actualModels = [];
-  let stateSelector: any = null;
-  let actionSelector: any = null;
+  const selectors = [];
 
   for (const model of models) {
-    if (typeof model === 'function' && !isModel(model)) {
-      if (!stateSelector) {
-        stateSelector = model;
-      } else if (!actionSelector) {
-        actionSelector = model;
-      }
-
-      continue;
+    if (isModel(model)) {
+      actualModels.push(model);
+    } else {
+      selectors.push(model);
     }
-
-    actualModels.push(model);
   }
+  let [stateSelector, actionSelector] = selectors;
 
   if (actualModels.length > 1) {
     actualModels.forEach(m => {


### PR DESCRIPTION
```
      const [state, actions] = useModel(
        modelA,
        modelB,
        undefined,
        (actionsA, actionsB) => {
          return {
            ...actionsA,
            ...actionsB,
            incAB() {
              actionsA.incA();
              actionsB.incB();
            },
          };
        },
      );
```