### PR TITLE
feat: remove `extraArgs` param

### DIFF
--- a/packages/store/src/__test__/onMount.test.ts
+++ b/packages/store/src/__test__/onMount.test.ts
@@ -83,7 +83,6 @@ describe('test onMount hook', () => {
         expect(result).toEqual({
           type: 'COUNT/ADDVALUE',
           payload: 1,
-          extraArgs: [],
         });
       });
     };

--- a/packages/store/src/model/mountModel.ts
+++ b/packages/store/src/model/mountModel.ts
@@ -165,7 +165,7 @@ const createReducer = <S = any>(
         'beforeReducer',
         flattenedActions[reduxAction.type],
         { name: reduxAction.type, computedDescriptors },
-      )(state, reduxAction.payload, ...(reduxAction.extraArgs || []));
+      )(state, reduxAction.payload);
     }
 
     if (computedDescriptors && getStateType(newState) !== StateType.Object) {
@@ -263,11 +263,10 @@ const createDispatchActions = (
   };
 
   forEachAction(modelDesc, path =>
-    set(path, (payload: any, ...extraArgs: any[]) => {
+    set(path, (payload: any) => {
       return context.store.dispatch({
         type: path.join('/').toUpperCase(),
         payload,
-        extraArgs,
       });
     }),
   );

--- a/packages/store/src/types/model.ts
+++ b/packages/store/src/types/model.ts
@@ -3,7 +3,6 @@ import { Context } from './app';
 export type Action<State, Payload = any> = (
   state: State,
   payload: Payload,
-  ...extraArgs: any[]
 ) => State | void;
 
 export interface Actions<State> {


### PR DESCRIPTION

Actions has a  default `extraArgs` params, which seems unnecessary. So remove it for now. 