### PR TITLE
revert: feat: remove `extraArgs` param #67

### DIFF
--- a/packages/plugins/immer/src/index.ts
+++ b/packages/plugins/immer/src/index.ts
@@ -7,7 +7,7 @@ setAutoFreeze(false);
 
 export default createPlugin(() => ({
   beforeReducer(reducer) {
-    return (state: any, payload: any) =>
-      produce(state, (draft: any) => reducer(draft, payload));
+    return (state: any, payload: any, ...extraArgs: any[]) =>
+      produce(state, (draft: any) => reducer(draft, payload, ...extraArgs));
   },
 }));

--- a/packages/store/src/__test__/onMount.test.ts
+++ b/packages/store/src/__test__/onMount.test.ts
@@ -83,6 +83,7 @@ describe('test onMount hook', () => {
         expect(result).toEqual({
           type: 'COUNT/ADDVALUE',
           payload: 1,
+          extraArgs: [],
         });
       });
     };

--- a/packages/store/src/model/mountModel.ts
+++ b/packages/store/src/model/mountModel.ts
@@ -165,7 +165,7 @@ const createReducer = <S = any>(
         'beforeReducer',
         flattenedActions[reduxAction.type],
         { name: reduxAction.type, computedDescriptors },
-      )(state, reduxAction.payload);
+      )(state, reduxAction.payload, ...(reduxAction.extraArgs || []));
     }
 
     if (computedDescriptors && getStateType(newState) !== StateType.Object) {
@@ -263,10 +263,11 @@ const createDispatchActions = (
   };
 
   forEachAction(modelDesc, path =>
-    set(path, (payload: any) => {
+    set(path, (payload: any, ...extraArgs: any[]) => {
       return context.store.dispatch({
         type: path.join('/').toUpperCase(),
         payload,
+        extraArgs,
       });
     }),
   );

--- a/packages/store/src/types/model.ts
+++ b/packages/store/src/types/model.ts
@@ -3,6 +3,7 @@ import { Context } from './app';
 export type Action<State, Payload = any> = (
   state: State,
   payload: Payload,
+  ...extraArgs: any[]
 ) => State | void;
 
 export interface Actions<State> {


### PR DESCRIPTION
1. Revert #67 . Since in some scenarios such as auto action `splice` for array state, we need action `extraArgs`.
2. Fix plugin-immer not support  action `extraArgs` .