### PR TITLE
chore: remove redux-thunk

### DIFF
--- a/packages/plugins/effects/package.json
+++ b/packages/plugins/effects/package.json
@@ -40,8 +40,7 @@
   "dependencies": {
     "@babel/runtime": "^7",
     "redux": "^4.1.1",
-    "redux-promise-middleware": "^6.1.2",
-    "redux-thunk": "^2.3.0"
+    "redux-promise-middleware": "^6.1.2"
   },
   "devDependencies": {
     "@modern-js-reduck/store": "workspace:*",

--- a/packages/plugins/effects/src/plugin.ts
+++ b/packages/plugins/effects/src/plugin.ts
@@ -1,7 +1,6 @@
 import { createPlugin } from '@modern-js-reduck/store';
 import { Model } from '@modern-js-reduck/store/dist/types/types';
 import { createPromise } from 'redux-promise-middleware';
-import thunk from 'redux-thunk';
 
 type AsyncEffect = (...args: any[]) => Promise<any>;
 type VoidEffect = (...args: any[]) => void;
@@ -92,9 +91,9 @@ const plugin = createPlugin(context => ({
     return {
       ...storeConfig,
       middlewares: [
-        ...(storeConfig.middlewares || []),
         createPromise({ promiseTypeDelimiter: '/' }),
-        thunk, // currently thunk cannot work with reduck correctlly, maybe we can just remove this style of effects
+        // middlewares from config are at the end
+        ...(storeConfig.middlewares || []),
       ],
     };
   },


### PR DESCRIPTION
 `redux-thunk` is unnecessary for now,  so remove it.  