### PR TITLE
Revert "feat: add `getStore` API (#75)"

### DIFF
--- a/packages/react/src/createApp.tsx
+++ b/packages/react/src/createApp.tsx
@@ -80,7 +80,7 @@ export const createApp = (config: Config = {}) => {
   }>(null as any);
 
   const defaultPlugins = getDefaultPlugins(config);
-  let store: Store;
+
   const Provider = (
     props: PropsWithChildren<{ store?: Store; config?: Config }>,
   ) => {
@@ -89,7 +89,7 @@ export const createApp = (config: Config = {}) => {
     // user setting would override default plugins
     configFromProvider.plugins = configFromProvider.plugins || defaultPlugins;
 
-    store = storeFromProps || createStore(configFromProvider);
+    const store = storeFromProps || createStore(configFromProvider);
     const batchManager = createBatchManager(store);
 
     return (
@@ -250,13 +250,14 @@ export const createApp = (config: Config = {}) => {
     }, [])(...args);
   };
 
-  const getStore: () => Store = () => {
+  const useStore: () => Store = () => {
+    const { store } = useContext(Context);
     return store;
   };
 
   return {
     Provider,
-    getStore,
+    useStore,
     useModel,
     useStaticModel,
     useLocalModel,

--- a/packages/react/src/hook.ts
+++ b/packages/react/src/hook.ts
@@ -1,6 +1,6 @@
 import { createApp } from './createApp';
 
-const { Provider, useModel, useStaticModel, useLocalModel, getStore } =
+const { Provider, useModel, useStaticModel, useLocalModel, useStore } =
   createApp({});
 
-export { Provider, useModel, useStaticModel, useLocalModel, getStore };
+export { Provider, useModel, useStaticModel, useLocalModel, useStore };


### PR DESCRIPTION
Revert #75 .

`getStore`  would make the `store` global, which may cause  inconsistency  in SSR situation. So revert to `useStore`  Hook.