### PR TITLE
feat: set `onlyUpdatePeerDependentsWhenOutOfRange`

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,5 +6,8 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  },
   "ignore": []
 }

--- a/packages/plugins/effects/package.json
+++ b/packages/plugins/effects/package.json
@@ -56,7 +56,7 @@
   "modernSettings": {},
   "sideEffects": false,
   "peerDependencies": {
-    "@modern-js-reduck/store": "^1.0.6"
+    "@modern-js-reduck/store": "workspace:*"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/plugins/xstate-immer/package.json
+++ b/packages/plugins/xstate-immer/package.json
@@ -60,8 +60,8 @@
   "modernSettings": {},
   "sideEffects": false,
   "peerDependencies": {
-    "@modern-js-reduck/store": "^1.0.6",
-    "@modern-js-reduck/plugin-xstate": "^1.0.4"
+    "@modern-js-reduck/store": "workspace:*",
+    "@modern-js-reduck/plugin-xstate": "workspace:*"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",


### PR DESCRIPTION
This PR would prevent changeset bump major version when peerDependencies upgrade minor version. 