### PR TITLE
feat: export utils from index

### DIFF
--- a/packages/plugins/auto-actions/src/index.ts
+++ b/packages/plugins/auto-actions/src/index.ts
@@ -1,6 +1,5 @@
-import { createPlugin } from '@modern-js-reduck/store';
+import { createPlugin, utils } from '@modern-js-reduck/store';
 import { Model } from '@modern-js-reduck/store/dist/types/types';
-import { getStateType } from '@modern-js-reduck/store/utils';
 import { mergeActions } from './utils';
 import * as primitiveActions from './primitive';
 import { ArrayDispatchActions } from './array';
@@ -38,7 +37,7 @@ declare module '@modern-js-reduck/store' {
 export default createPlugin(() => ({
   prepareModelDesc(modelDesc) {
     const initialState = modelDesc.state;
-    const type = getStateType(initialState);
+    const type = utils.getStateType(initialState);
 
     if (type === 'primitive') {
       return mergeActions(modelDesc, primitiveActions);

--- a/packages/react/src/batchManager.ts
+++ b/packages/react/src/batchManager.ts
@@ -1,6 +1,5 @@
-import { Store, Model } from '@modern-js-reduck/store';
+import { Store, Model, utils } from '@modern-js-reduck/store';
 import { unstable_batchedUpdates } from 'react-dom';
-import { isModel } from '@modern-js-reduck/store/utils';
 
 const combineSubscribe = (
   store: Store,
@@ -78,7 +77,7 @@ const createBatchManager = (store: Store) => {
 
   const changeModels = (action: 'remove' | 'add', ...models: Model[]) => {
     models.forEach(model => {
-      if (!isModel(model)) {
+      if (!utils.isModel(model)) {
         return;
       }
 

--- a/packages/react/src/connect.tsx
+++ b/packages/react/src/connect.tsx
@@ -4,7 +4,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import type { ComponentType, NamedExoticComponent } from 'react';
 import { forwardRef, memo } from 'react';
-import { isModel } from '@modern-js-reduck/store/utils';
+import { utils } from '@modern-js-reduck/store';
 
 import type {
   Model,
@@ -394,7 +394,7 @@ function withProxy<P extends object, S extends object, A extends object>(
   const modelArr = Array.isArray(models) ? models : [models];
 
   for (const model of modelArr) {
-    if (isModel(model)) {
+    if (utils.isModel(model)) {
       actualModels.push(model);
     } else {
       selectors.push(model);

--- a/packages/react/src/createApp.tsx
+++ b/packages/react/src/createApp.tsx
@@ -1,4 +1,4 @@
-import { createStore } from '@modern-js-reduck/store';
+import { createStore, utils } from '@modern-js-reduck/store';
 import React, {
   createContext,
   useContext,
@@ -16,7 +16,6 @@ import autoActionsPlugin from '@modern-js-reduck/plugin-auto-actions';
 import devToolsPlugin, {
   DevToolsOptions,
 } from '@modern-js-reduck/plugin-devtools';
-import { isModel } from '@modern-js-reduck/store/utils';
 import { useIsomorphicLayoutEffect } from './utils/useIsomorphicLayoutEffect';
 import { createBatchManager } from './batchManager';
 
@@ -134,7 +133,7 @@ export const createApp = (config: Config = {}) => {
       const args = _args.flat();
       // don't depend on stateSelectors and actionSelectors,
       // since they are inline usually and their references always change
-      const deps: Model[] = args.filter(item => isModel(item));
+      const deps: Model[] = args.filter(item => utils.isModel(item));
       const initialValue = useMemo(() => store.use(...args), [store, ...deps]);
       const [modelValue, setModelValue] = useState(initialValue);
 

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -1,6 +1,7 @@
 import createStore from './store/createStore';
 import model from './model/model';
 import { createPlugin } from './plugin';
+import * as utils from './utils';
 
 export type {
   ModelDesc,
@@ -13,4 +14,4 @@ export type {
   Model,
 } from '@/types';
 
-export { createStore, model, createPlugin };
+export { createStore, model, createPlugin, utils };


### PR DESCRIPTION

Export util functions from  main entry  instead of [subpath entry](https://nodejs.org/dist/latest-v12.x/docs/api/packages.html#packages_subpath_exports) , in order to compat Jest.

Jest currently doesn't support subpath exports by default. Refer  [#9430](https://github.com/facebook/jest/issues/9430)、[#9565](https://github.com/facebook/jest/issues/9565).