### PR TITLE
build: add `packageManger` 

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "@commitlint/config-conventional": "^17.0.0",
     "@modern-js-reduck/scripts": "workspace:*",
     "@modern-js/monorepo-tools": "^1.19.0",
-    "@modern-js/plugin-jarvis": "^1.19.0",
     "@modern-js/tsconfig": "^1.19.0",
     "husky": "^8.0.0",
     "lint-staged": "^11.2.6",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@modern-js/plugin-jarvis": "^1.19.0",
     "@modern-js/tsconfig": "^1.19.0",
     "husky": "^8.0.0",
+    "lint-staged": "^11.2.6",
     "webpack": "^5.54.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "engines": {
     "node": ">=12.13.0"
   },
+  "packageManager": "pnpm@7.12.2",
   "commitlint": {
     "extends": [
       "@commitlint/config-conventional"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ importers:
       '@modern-js/plugin-jarvis': ^1.19.0
       '@modern-js/tsconfig': ^1.19.0
       husky: ^8.0.0
+      lint-staged: ^11.2.6
       webpack: ^5.54.0
     devDependencies:
       '@commitlint/cli': 17.0.3
@@ -20,6 +21,7 @@ importers:
       '@modern-js/plugin-jarvis': 1.19.0
       '@modern-js/tsconfig': 1.19.0
       husky: 8.0.1
+      lint-staged: 11.2.6
       webpack: 5.74.0
 
   examples/todos:


### PR DESCRIPTION
1. Add `packageManger`  to support  Node.js  [corapack](https://nodejs.org/api/corepack.html).
2. Add dep `lint-staged` since we won't hoist it.
3. Remove dep `@modern-js/plugin-jarvis` since it is the dep of `@modern-js/app-tools` now.