### PR TITLE
fix:  missing getServerSnapshot

### DIFF
--- a/packages/plugins/auto-actions/CHANGELOG.md
+++ b/packages/plugins/auto-actions/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @modern-js-reduck/plugin-auto-actions
 
+## 1.1.3
+
+### Patch Changes
+
+- @modern-js-reduck/store@1.1.3
+
 ## 1.1.2
 
 ### Patch Changes

--- a/packages/plugins/auto-actions/package.json
+++ b/packages/plugins/auto-actions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js-reduck/plugin-auto-actions",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "files": [
     "dist"
   ],
@@ -52,7 +52,7 @@
   "modernSettings": {},
   "sideEffects": false,
   "peerDependencies": {
-    "@modern-js-reduck/store": "workspace:^1.1.2"
+    "@modern-js-reduck/store": "workspace:^1.1.3"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/plugins/devtools/CHANGELOG.md
+++ b/packages/plugins/devtools/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @modern-js-reduck/plugin-devtools
 
+## 1.1.3
+
+### Patch Changes
+
+- @modern-js-reduck/store@1.1.3
+
 ## 1.1.2
 
 ### Patch Changes

--- a/packages/plugins/devtools/package.json
+++ b/packages/plugins/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js-reduck/plugin-devtools",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "files": [
     "dist"
   ],
@@ -54,7 +54,7 @@
   "modernSettings": {},
   "sideEffects": false,
   "peerDependencies": {
-    "@modern-js-reduck/store": "workspace:^1.1.2"
+    "@modern-js-reduck/store": "workspace:^1.1.3"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/plugins/effects/CHANGELOG.md
+++ b/packages/plugins/effects/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @modern-js-reduck/plugin-effects
 
+## 1.1.3
+
+### Patch Changes
+
+- @modern-js-reduck/store@1.1.3
+
 ## 1.1.2
 
 ### Patch Changes

--- a/packages/plugins/effects/package.json
+++ b/packages/plugins/effects/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js-reduck/plugin-effects",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "files": [
     "dist"
   ],
@@ -56,7 +56,7 @@
   "modernSettings": {},
   "sideEffects": false,
   "peerDependencies": {
-    "@modern-js-reduck/store": "workspace:^1.1.2"
+    "@modern-js-reduck/store": "workspace:^1.1.3"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/plugins/immer/CHANGELOG.md
+++ b/packages/plugins/immer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @modern-js-reduck/plugin-immutable
 
+## 1.1.3
+
+### Patch Changes
+
+- @modern-js-reduck/store@1.1.3
+
 ## 1.1.2
 
 ### Patch Changes

--- a/packages/plugins/immer/package.json
+++ b/packages/plugins/immer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js-reduck/plugin-immutable",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "files": [
     "dist"
   ],
@@ -53,7 +53,7 @@
   "modernSettings": {},
   "sideEffects": false,
   "peerDependencies": {
-    "@modern-js-reduck/store": "workspace:^1.1.2"
+    "@modern-js-reduck/store": "workspace:^1.1.3"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/plugins/xstate-immer/package.json
+++ b/packages/plugins/xstate-immer/package.json
@@ -60,7 +60,7 @@
   "modernSettings": {},
   "sideEffects": false,
   "peerDependencies": {
-    "@modern-js-reduck/store": "workspace:^1.1.2",
+    "@modern-js-reduck/store": "workspace:^1.1.3",
     "@modern-js-reduck/plugin-xstate": "workspace:^1.1.0"
   },
   "publishConfig": {

--- a/packages/plugins/xstate/package.json
+++ b/packages/plugins/xstate/package.json
@@ -54,7 +54,7 @@
   "modernSettings": {},
   "sideEffects": false,
   "peerDependencies": {
-    "@modern-js-reduck/store": "workspace:^1.1.2"
+    "@modern-js-reduck/store": "workspace:^1.1.3"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @modern-js-reduck/react
 
+## 1.1.3
+
+### Patch Changes
+
+- fix: missing getServerSnapshot in SSR
+  - @modern-js-reduck/plugin-auto-actions@1.1.3
+  - @modern-js-reduck/plugin-devtools@1.1.3
+  - @modern-js-reduck/plugin-effects@1.1.3
+  - @modern-js-reduck/plugin-immutable@1.1.3
+  - @modern-js-reduck/store@1.1.3
+
 ## 1.1.2
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js-reduck/react",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "files": [
     "dist",
     "type.d.ts"

--- a/packages/react/src/createApp.tsx
+++ b/packages/react/src/createApp.tsx
@@ -107,7 +107,7 @@ export const createApp = (config: Config = {}) => {
 
       const lastValueRef = useRef<ReturnType<typeof store.use>>(initialValue);
 
-      const getSnapshot = () => {
+      const getSnapshot = useCallback(() => {
         const newValue = store.use(...args);
         if (!shallowEqual(lastValueRef.current[0], newValue[0])) {
           lastValueRef.current = newValue;
@@ -115,11 +115,15 @@ export const createApp = (config: Config = {}) => {
         } else {
           return lastValueRef.current;
         }
-      };
+      }, [store, ...args]);
 
       const selectedState = useSyncExternalStore(
         initialValue[2],
-        useCallback(getSnapshot, [store, ...args]),
+        getSnapshot,
+        // The third parameter is required in SSR.
+        // The initial state should be set when createStore in hydration stage,
+        // so we can use the same getSnapshot to get state.
+        getSnapshot,
       );
 
       return selectedState;

--- a/packages/store/CHANGELOG.md
+++ b/packages/store/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js-reduck/store
 
+## 1.1.3
+
 ## 1.1.2
 
 ### Patch Changes

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modern-js-reduck/store",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "files": [
     "dist"
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,6 @@ importers:
       '@commitlint/config-conventional': ^17.0.0
       '@modern-js-reduck/scripts': workspace:*
       '@modern-js/monorepo-tools': ^1.19.0
-      '@modern-js/plugin-jarvis': ^1.19.0
       '@modern-js/tsconfig': ^1.19.0
       husky: ^8.0.0
       lint-staged: ^11.2.6
@@ -18,7 +17,6 @@ importers:
       '@commitlint/config-conventional': 17.0.3
       '@modern-js-reduck/scripts': link:scripts
       '@modern-js/monorepo-tools': 1.19.0
-      '@modern-js/plugin-jarvis': 1.19.0
       '@modern-js/tsconfig': 1.19.0
       husky: 8.0.1
       lint-staged: 11.2.6
@@ -58,7 +56,7 @@ importers:
     specifiers:
       serve: latest
     dependencies:
-      serve: 14.0.1
+      serve: 14.1.2
 
   examples/vite-counter:
     specifiers:
@@ -352,13 +350,13 @@ importers:
       redux: 4.2.0
     devDependencies:
       '@modern-js-reduck/scripts': link:../../scripts
-      '@modern-js/module-tools': 1.15.0_typescript@4.8.4
-      '@modern-js/plugin-testing': 1.15.0_ctdkshhq2lm627737wy4l2wzxm
-      '@modern-js/runtime': 1.15.0_typescript@4.8.4
+      '@modern-js/module-tools': 1.15.0_typescript@4.9.3
+      '@modern-js/plugin-testing': 1.15.0_gvqlmu5dawaiexdbitsitsv6zm
+      '@modern-js/runtime': 1.15.0_typescript@4.9.3
       '@types/jest': 27.5.2
       '@types/node': 14.18.25
-      tsd: 0.24.1
-      typescript: 4.8.4
+      tsd: 0.25.0
+      typescript: 4.9.3
 
   scripts:
     specifiers: {}
@@ -2060,10 +2058,10 @@ packages:
       '@types/node': 18.7.9
       chalk: 4.1.2
       cosmiconfig: 7.0.1
-      cosmiconfig-typescript-loader: 2.0.2_fxotr6iqnckpi76swcl5uzszdi
+      cosmiconfig-typescript-loader: 2.0.2_h4zlp2d3lea7bhgzysddfhpaja
       lodash: 4.17.21
       resolve-from: 5.0.0
-      typescript: 4.8.4
+      typescript: 4.9.3
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -2734,8 +2732,8 @@ packages:
       '@babel/eslint-parser': 7.18.9_n7v3jrcw44h2iashmp3c6zuigi
       '@babel/eslint-plugin': 7.18.10_mmkctkpdzgrnnk4vqshj6aqewa
       '@modern-js/babel-preset-app': 1.15.0
-      '@typescript-eslint/eslint-plugin': 5.33.1_ilkrvp4egqxnrc4vbjsnnk4qki
-      '@typescript-eslint/parser': 5.33.1_3rubbgt5ekhqrcgx4uwls3neim
+      '@typescript-eslint/eslint-plugin': 5.33.1_d46j6vkovpxle5yjzgjzb2yetu
+      '@typescript-eslint/parser': 5.33.1_77fvizpdb3y4icyeo2mf4eo7em
       eslint: 7.32.0
       eslint-config-prettier: 8.5.0_eslint@7.32.0
       eslint-plugin-eslint-comments: 3.2.0_eslint@7.32.0
@@ -2748,7 +2746,7 @@ packages:
       eslint-plugin-react: 7.30.1_eslint@7.32.0
       eslint-plugin-react-hooks: 4.6.0_eslint@7.32.0
       prettier: 2.7.1
-      typescript: 4.8.4
+      typescript: 4.9.3
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -2762,8 +2760,8 @@ packages:
       '@babel/eslint-parser': 7.18.9_n7v3jrcw44h2iashmp3c6zuigi
       '@babel/eslint-plugin': 7.18.10_mmkctkpdzgrnnk4vqshj6aqewa
       '@modern-js/babel-preset-app': 1.18.1
-      '@typescript-eslint/eslint-plugin': 5.33.1_ilkrvp4egqxnrc4vbjsnnk4qki
-      '@typescript-eslint/parser': 5.33.1_3rubbgt5ekhqrcgx4uwls3neim
+      '@typescript-eslint/eslint-plugin': 5.33.1_d46j6vkovpxle5yjzgjzb2yetu
+      '@typescript-eslint/parser': 5.33.1_77fvizpdb3y4icyeo2mf4eo7em
       eslint: 7.32.0
       eslint-config-prettier: 8.5.0_eslint@7.32.0
       eslint-plugin-eslint-comments: 3.2.0_eslint@7.32.0
@@ -2776,7 +2774,7 @@ packages:
       eslint-plugin-react: 7.30.1_eslint@7.32.0
       eslint-plugin-react-hooks: 4.6.0_eslint@7.32.0
       prettier: 2.7.1
-      typescript: 4.8.4
+      typescript: 4.9.3
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -3282,7 +3280,7 @@ packages:
       - webpack-cli
     dev: true
 
-  /@modern-js/module-tools/1.15.0_typescript@4.8.4:
+  /@modern-js/module-tools/1.15.0_typescript@4.9.3:
     resolution: {integrity: sha512-iI3Lnef90/6ZGf6YmQmdmzqOa4VMTRUTOt3FbJcTSTHE+bZ2e/vPgzHaU7Ln1qLmBzbkgZwV0CT/gLQWsq13Hg==}
     hasBin: true
     dependencies:
@@ -3310,7 +3308,7 @@ packages:
       p-map: 4.0.0
       process.argv: 0.6.0
       rollup: 2.78.1
-      rollup-plugin-dts: 4.2.2_rgdoxrudhz5lxzgmaosvkjax6q
+      rollup-plugin-dts: 4.2.2_teuuio47mkv7m5wkpe7h6dmyqa
       rollup-plugin-hashbang: 3.0.0_rollup@2.78.1
       signal-exit: 3.0.7
     transitivePeerDependencies:
@@ -3599,7 +3597,7 @@ packages:
       - webpack-plugin-serve
     dev: true
 
-  /@modern-js/plugin-testing/1.15.0_ctdkshhq2lm627737wy4l2wzxm:
+  /@modern-js/plugin-testing/1.15.0_gvqlmu5dawaiexdbitsitsv6zm:
     resolution: {integrity: sha512-EHFIwyiTx9r0wo6O9XBhHfBT0xTFExxjzzoYzEMPFGu5UnuN1/ZJBOK5XyUaKy2aZHqJ4jzh+2oRxcaHSSXkNA==}
     peerDependencies:
       '@modern-js/runtime': ^1.15.0
@@ -3617,10 +3615,10 @@ packages:
       '@modern-js/babel-compiler': 1.15.0
       '@modern-js/babel-preset-app': 1.15.0
       '@modern-js/plugin': 1.15.0
-      '@modern-js/runtime': 1.15.0_typescript@4.8.4
-      '@modern-js/server': 1.15.0_typescript@4.8.4
+      '@modern-js/runtime': 1.15.0_typescript@4.9.3
+      '@modern-js/server': 1.15.0_typescript@4.9.3
       '@modern-js/utils': 1.15.0
-      '@modern-js/webpack': 1.15.0_typescript@4.8.4
+      '@modern-js/webpack': 1.15.0_typescript@4.9.3
       '@testing-library/jest-dom': 5.16.5
       '@testing-library/react': 12.1.5
       '@types/testing-library__jest-dom': 5.14.5
@@ -3631,7 +3629,7 @@ packages:
       jest-environment-node: 27.5.1
       path-to-regexp: 6.2.1
       supertest: 6.2.4
-      ts-jest: 27.1.5_ycphgmgat7mqbvnmadx6worcm4
+      ts-jest: 27.1.5_bffvhrluba3bbf5vkfeb3vnecy
       yargs: 17.5.1
     transitivePeerDependencies:
       - '@parcel/css'
@@ -3696,7 +3694,7 @@ packages:
       - supports-color
     dev: true
 
-  /@modern-js/runtime/1.15.0_typescript@4.8.4:
+  /@modern-js/runtime/1.15.0_typescript@4.9.3:
     resolution: {integrity: sha512-c++N494wEBKg0c8UCtUQry8DKssRm0ee+yLLVKu2KwaGE7xllG6Mhk7TNNSvKUJgUtlnCMof3/y+teW354utww==}
     dependencies:
       '@babel/core': 7.18.10
@@ -3712,7 +3710,7 @@ packages:
       '@modern-js-reduck/store': 1.0.6
       '@modern-js/plugin': 1.15.0
       '@modern-js/utils': 1.15.0
-      '@modern-js/webpack': 1.15.0_typescript@4.8.4
+      '@modern-js/webpack': 1.15.0_typescript@4.9.3
       '@types/history': 4.7.11
       '@types/loadable__component': 5.13.4
       '@types/react-helmet': 6.1.5
@@ -3814,7 +3812,7 @@ packages:
       - webpack-plugin-serve
     dev: true
 
-  /@modern-js/server/1.15.0_typescript@4.8.4:
+  /@modern-js/server/1.15.0_typescript@4.9.3:
     resolution: {integrity: sha512-zf9p10GwFzEuZkemD2BVZOD1+SIthUZr+Yj6X06jqJuKudJz6vjVTyC5ootn3NN4gFU8vOQgqdVbnGoE0OHkAQ==}
     dependencies:
       '@babel/core': 7.18.10
@@ -3822,7 +3820,7 @@ packages:
       '@modern-js/prod-server': 1.15.0
       '@modern-js/server-utils': 1.15.0
       '@modern-js/utils': 1.15.0
-      '@modern-js/webpack': 1.15.0_typescript@4.8.4
+      '@modern-js/webpack': 1.15.0_typescript@4.9.3
       devcert: 1.2.2
       minimatch: 3.1.2
       path-to-regexp: 6.2.1
@@ -3945,7 +3943,7 @@ packages:
       - webpack-plugin-serve
     dev: true
 
-  /@modern-js/webpack/1.15.0_typescript@4.8.4:
+  /@modern-js/webpack/1.15.0_typescript@4.9.3:
     resolution: {integrity: sha512-vh3qLHu3onAHFSI4fpGkCy60zHcglJsjQKyKWteW3WVLHrbbnxJCYbfCafwho5IrzIg01Z0O0/PhOv8/y38bfA==}
     dependencies:
       '@babel/core': 7.18.10
@@ -3956,7 +3954,7 @@ packages:
       '@svgr/webpack': 6.3.1
       core-js: 3.24.1
       css-minimizer-webpack-plugin: 3.4.1_webpack@5.74.0
-      fork-ts-checker-webpack-plugin: 7.2.13_qqxisngxjbp7lstdk7boexbu3e
+      fork-ts-checker-webpack-plugin: 7.2.13_ioost42n2pkm3q6vbnx4ypyu7a
       html-loader: 3.1.0_webpack@5.74.0
       html-webpack-plugin: 5.5.0_webpack@5.74.0
       mini-css-extract-plugin: 2.4.7_webpack@5.74.0
@@ -3967,7 +3965,7 @@ packages:
       style-loader: 3.3.1_webpack@5.74.0
       tapable: 2.2.1
       terser-webpack-plugin: 5.3.5_webpack@5.74.0
-      ts-loader: 9.3.1_qqxisngxjbp7lstdk7boexbu3e
+      ts-loader: 9.3.1_ioost42n2pkm3q6vbnx4ypyu7a
       webpack: 5.74.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -4960,8 +4958,8 @@ packages:
     resolution: {integrity: sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==}
     dev: true
 
-  /@tsd/typescript/4.8.4:
-    resolution: {integrity: sha512-WMFNVstwWGyDuZP2LGPRZ+kPHxZLmhO+2ormstDvnXiyoBPtW1qq9XhhrkI4NVtxgs+2ZiUTl9AG7nNIRq/uCg==}
+  /@tsd/typescript/4.9.3:
+    resolution: {integrity: sha512-iyi45620s9QN62rW90KelRJLG7p15g4NhTezxYCHmE5RY/BI270Sn7E8vWtiLzB+9mQgy71sYXcgyDKjtJamSQ==}
     dev: true
 
   /@types/aria-query/4.2.2:
@@ -5366,7 +5364,7 @@ packages:
       '@types/yargs-parser': 21.0.0
     dev: false
 
-  /@typescript-eslint/eslint-plugin/5.33.1_ilkrvp4egqxnrc4vbjsnnk4qki:
+  /@typescript-eslint/eslint-plugin/5.33.1_d46j6vkovpxle5yjzgjzb2yetu:
     resolution: {integrity: sha512-S1iZIxrTvKkU3+m63YUOxYPKaP+yWDQrdhxTglVDVEVBf+aCSw85+BmJnyUaQQsk5TXFG/LpBu9fa+LrAQ91fQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5377,18 +5375,18 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.33.1_3rubbgt5ekhqrcgx4uwls3neim
+      '@typescript-eslint/parser': 5.33.1_77fvizpdb3y4icyeo2mf4eo7em
       '@typescript-eslint/scope-manager': 5.33.1
-      '@typescript-eslint/type-utils': 5.33.1_3rubbgt5ekhqrcgx4uwls3neim
-      '@typescript-eslint/utils': 5.33.1_3rubbgt5ekhqrcgx4uwls3neim
+      '@typescript-eslint/type-utils': 5.33.1_77fvizpdb3y4icyeo2mf4eo7em
+      '@typescript-eslint/utils': 5.33.1_77fvizpdb3y4icyeo2mf4eo7em
       debug: 4.3.4
       eslint: 7.32.0
       functional-red-black-tree: 1.0.1
       ignore: 5.2.0
       regexpp: 3.2.0
       semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.8.4
-      typescript: 4.8.4
+      tsutils: 3.21.0_typescript@4.9.3
+      typescript: 4.9.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5473,26 +5471,6 @@ packages:
       - typescript
     dev: false
 
-  /@typescript-eslint/parser/5.33.1_3rubbgt5ekhqrcgx4uwls3neim:
-    resolution: {integrity: sha512-IgLLtW7FOzoDlmaMoXdxG8HOCByTBXrB1V2ZQYSEV1ggMmJfAkMWTwUjjzagS6OkfpySyhKFkBw7A9jYmcHpZA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 5.33.1
-      '@typescript-eslint/types': 5.33.1
-      '@typescript-eslint/typescript-estree': 5.33.1_typescript@4.8.4
-      debug: 4.3.4
-      eslint: 7.32.0
-      typescript: 4.8.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/parser/5.33.1_4rv7y5c6xz3vfxwhbrcxxi73bq:
     resolution: {integrity: sha512-IgLLtW7FOzoDlmaMoXdxG8HOCByTBXrB1V2ZQYSEV1ggMmJfAkMWTwUjjzagS6OkfpySyhKFkBw7A9jYmcHpZA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -5512,6 +5490,26 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
+
+  /@typescript-eslint/parser/5.33.1_77fvizpdb3y4icyeo2mf4eo7em:
+    resolution: {integrity: sha512-IgLLtW7FOzoDlmaMoXdxG8HOCByTBXrB1V2ZQYSEV1ggMmJfAkMWTwUjjzagS6OkfpySyhKFkBw7A9jYmcHpZA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 5.33.1
+      '@typescript-eslint/types': 5.33.1
+      '@typescript-eslint/typescript-estree': 5.33.1_typescript@4.9.3
+      debug: 4.3.4
+      eslint: 7.32.0
+      typescript: 4.9.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@typescript-eslint/parser/5.33.1_shit3uhl6a7megkzgoz6xssnfa:
     resolution: {integrity: sha512-IgLLtW7FOzoDlmaMoXdxG8HOCByTBXrB1V2ZQYSEV1ggMmJfAkMWTwUjjzagS6OkfpySyhKFkBw7A9jYmcHpZA==}
@@ -5540,25 +5538,6 @@ packages:
       '@typescript-eslint/types': 5.33.1
       '@typescript-eslint/visitor-keys': 5.33.1
 
-  /@typescript-eslint/type-utils/5.33.1_3rubbgt5ekhqrcgx4uwls3neim:
-    resolution: {integrity: sha512-X3pGsJsD8OiqhNa5fim41YtlnyiWMF/eKsEZGsHID2HcDqeSC5yr/uLOeph8rNF2/utwuI0IQoAK3fpoxcLl2g==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/utils': 5.33.1_3rubbgt5ekhqrcgx4uwls3neim
-      debug: 4.3.4
-      eslint: 7.32.0
-      tsutils: 3.21.0_typescript@4.8.4
-      typescript: 4.8.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/type-utils/5.33.1_4rv7y5c6xz3vfxwhbrcxxi73bq:
     resolution: {integrity: sha512-X3pGsJsD8OiqhNa5fim41YtlnyiWMF/eKsEZGsHID2HcDqeSC5yr/uLOeph8rNF2/utwuI0IQoAK3fpoxcLl2g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -5577,6 +5556,25 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
+
+  /@typescript-eslint/type-utils/5.33.1_77fvizpdb3y4icyeo2mf4eo7em:
+    resolution: {integrity: sha512-X3pGsJsD8OiqhNa5fim41YtlnyiWMF/eKsEZGsHID2HcDqeSC5yr/uLOeph8rNF2/utwuI0IQoAK3fpoxcLl2g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/utils': 5.33.1_77fvizpdb3y4icyeo2mf4eo7em
+      debug: 4.3.4
+      eslint: 7.32.0
+      tsutils: 3.21.0_typescript@4.9.3
+      typescript: 4.9.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@typescript-eslint/type-utils/5.33.1_shit3uhl6a7megkzgoz6xssnfa:
     resolution: {integrity: sha512-X3pGsJsD8OiqhNa5fim41YtlnyiWMF/eKsEZGsHID2HcDqeSC5yr/uLOeph8rNF2/utwuI0IQoAK3fpoxcLl2g==}
@@ -5643,7 +5641,7 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/typescript-estree/5.33.1_typescript@4.8.4:
+  /@typescript-eslint/typescript-estree/5.33.1_typescript@4.9.3:
     resolution: {integrity: sha512-JOAzJ4pJ+tHzA2pgsWQi4804XisPHOtbvwUyqsuuq8+y5B5GMZs7lI1xDWs6V2d7gE/Ez5bTGojSK12+IIPtXA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5658,28 +5656,10 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.8.4
-      typescript: 4.8.4
+      tsutils: 3.21.0_typescript@4.9.3
+      typescript: 4.9.3
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@typescript-eslint/utils/5.33.1_3rubbgt5ekhqrcgx4uwls3neim:
-    resolution: {integrity: sha512-uphZjkMaZ4fE8CR4dU7BquOV6u0doeQAr8n6cQenl/poMaIyJtBu8eys5uk6u5HiDH01Mj5lzbJ5SfeDz7oqMQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@types/json-schema': 7.0.11
-      '@typescript-eslint/scope-manager': 5.33.1
-      '@typescript-eslint/types': 5.33.1
-      '@typescript-eslint/typescript-estree': 5.33.1_typescript@4.8.4
-      eslint: 7.32.0
-      eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@7.32.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
     dev: true
 
   /@typescript-eslint/utils/5.33.1_4rv7y5c6xz3vfxwhbrcxxi73bq:
@@ -5699,6 +5679,24 @@ packages:
       - supports-color
       - typescript
     dev: false
+
+  /@typescript-eslint/utils/5.33.1_77fvizpdb3y4icyeo2mf4eo7em:
+    resolution: {integrity: sha512-uphZjkMaZ4fE8CR4dU7BquOV6u0doeQAr8n6cQenl/poMaIyJtBu8eys5uk6u5HiDH01Mj5lzbJ5SfeDz7oqMQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@types/json-schema': 7.0.11
+      '@typescript-eslint/scope-manager': 5.33.1
+      '@typescript-eslint/types': 5.33.1
+      '@typescript-eslint/typescript-estree': 5.33.1_typescript@4.9.3
+      eslint: 7.32.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@7.32.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
 
   /@typescript-eslint/utils/5.33.1_shit3uhl6a7megkzgoz6xssnfa:
     resolution: {integrity: sha512-uphZjkMaZ4fE8CR4dU7BquOV6u0doeQAr8n6cQenl/poMaIyJtBu8eys5uk6u5HiDH01Mj5lzbJ5SfeDz7oqMQ==}
@@ -7220,7 +7218,7 @@ packages:
   /core-util-is/1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
-  /cosmiconfig-typescript-loader/2.0.2_fxotr6iqnckpi76swcl5uzszdi:
+  /cosmiconfig-typescript-loader/2.0.2_h4zlp2d3lea7bhgzysddfhpaja:
     resolution: {integrity: sha512-KmE+bMjWMXJbkWCeY4FJX/npHuZPNr9XF9q9CIQ/bpFwi1qHfCmSiKarrCcRa0LO4fWjk93pVoeRtJAkTGcYNw==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
@@ -7229,8 +7227,8 @@ packages:
     dependencies:
       '@types/node': 18.7.9
       cosmiconfig: 7.0.1
-      ts-node: 10.9.1_fxotr6iqnckpi76swcl5uzszdi
-      typescript: 4.8.4
+      ts-node: 10.9.1_h4zlp2d3lea7bhgzysddfhpaja
+      typescript: 4.9.3
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -8476,7 +8474,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.33.1_3rubbgt5ekhqrcgx4uwls3neim
+      '@typescript-eslint/parser': 5.33.1_77fvizpdb3y4icyeo2mf4eo7em
       debug: 3.2.7
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.6
@@ -8601,7 +8599,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.33.1_3rubbgt5ekhqrcgx4uwls3neim
+      '@typescript-eslint/parser': 5.33.1_77fvizpdb3y4icyeo2mf4eo7em
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
       debug: 2.6.9
@@ -9429,7 +9427,7 @@ packages:
       webpack: 5.74.0
     dev: false
 
-  /fork-ts-checker-webpack-plugin/7.2.13_qqxisngxjbp7lstdk7boexbu3e:
+  /fork-ts-checker-webpack-plugin/7.2.13_ioost42n2pkm3q6vbnx4ypyu7a:
     resolution: {integrity: sha512-fR3WRkOb4bQdWB/y7ssDUlVdrclvwtyCUIHCfivAoYxq9dF7XfrDKbMdZIfwJ7hxIAqkYSGeU7lLJE6xrxIBdg==}
     engines: {node: '>=12.13.0', yarn: '>=1.0.0'}
     peerDependencies:
@@ -9452,7 +9450,7 @@ packages:
       schema-utils: 3.1.1
       semver: 7.3.7
       tapable: 2.2.1
-      typescript: 4.8.4
+      typescript: 4.9.3
       webpack: 5.74.0
     dev: true
 
@@ -14222,7 +14220,7 @@ packages:
       '@babel/code-frame': 7.18.6
     dev: true
 
-  /rollup-plugin-dts/4.2.2_rgdoxrudhz5lxzgmaosvkjax6q:
+  /rollup-plugin-dts/4.2.2_teuuio47mkv7m5wkpe7h6dmyqa:
     resolution: {integrity: sha512-A3g6Rogyko/PXeKoUlkjxkP++8UDVpgA7C+Tdl77Xj4fgEaIjPSnxRmR53EzvoYy97VMVwLAOcWJudaVAuxneQ==}
     engines: {node: '>=v12.22.11'}
     peerDependencies:
@@ -14231,7 +14229,7 @@ packages:
     dependencies:
       magic-string: 0.26.2
       rollup: 2.78.1
-      typescript: 4.8.4
+      typescript: 4.9.3
     optionalDependencies:
       '@babel/code-frame': 7.18.6
     dev: true
@@ -14471,14 +14469,14 @@ packages:
     dependencies:
       randombytes: 2.1.0
 
-  /serve-handler/6.1.3:
-    resolution: {integrity: sha512-FosMqFBNrLyeiIDvP1zgO6YoTzFYHxLDEIavhlmQ+knB2Z7l1t+kGLHkZIDN7UVWqQAmKI3D20A6F6jo3nDd4w==}
+  /serve-handler/6.1.5:
+    resolution: {integrity: sha512-ijPFle6Hwe8zfmBxJdE+5fta53fdIY0lHISJvuikXB3VYFafRjMRpOffSPvCYsbKyBA7pvy9oYr/BT1O3EArlg==}
     dependencies:
       bytes: 3.0.0
       content-disposition: 0.5.2
       fast-url-parser: 1.1.3
       mime-types: 2.1.18
-      minimatch: 3.0.4
+      minimatch: 3.1.2
       path-is-inside: 1.0.2
       path-to-regexp: 2.2.1
       range-parser: 1.2.0
@@ -14510,8 +14508,8 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /serve/14.0.1:
-    resolution: {integrity: sha512-tNGwxl27FwA8TbmMQqN0jTaSx8/trL532qZsJHX1VdiEIjjtMJHCs7AFS6OvtC7cTHOvmjXqt5yczejU6CV2Xg==}
+  /serve/14.1.2:
+    resolution: {integrity: sha512-luwVfJwbeE7dhCKeRU0vIBpt4bXdbAfzwsWJIQ5eqrIW2e+4nLWXbSlZ0WzelSFHQq+FlueOW6dr90jEewS9zw==}
     engines: {node: '>= 14'}
     hasBin: true
     dependencies:
@@ -14524,7 +14522,7 @@ packages:
       clipboardy: 3.0.0
       compression: 1.7.4
       is-port-reachable: 4.0.0
-      serve-handler: 6.1.3
+      serve-handler: 6.1.5
       update-check: 1.5.4
     transitivePeerDependencies:
       - supports-color
@@ -15362,6 +15360,42 @@ packages:
     resolution: {integrity: sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==}
     dev: false
 
+  /ts-jest/27.1.5_bffvhrluba3bbf5vkfeb3vnecy:
+    resolution: {integrity: sha512-Xv6jBQPoBEvBq/5i2TeSG9tt/nqkbpcurrEG1b+2yfBrcJelOZF9Ml6dmyMh7bcW9JyFbRYpR5rxROSlBLTZHA==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@types/jest': ^27.0.0
+      babel-jest: '>=27.0.0 <28'
+      esbuild: '*'
+      jest: ^27.0.0
+      typescript: '>=3.8 <5.0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@types/jest':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+    dependencies:
+      '@babel/core': 7.18.10
+      '@types/jest': 27.5.2
+      babel-jest: 27.5.1_@babel+core@7.18.10
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      jest: 27.5.1
+      jest-util: 27.5.1
+      json5: 2.2.1
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.3.7
+      typescript: 4.9.3
+      yargs-parser: 20.2.9
+    dev: true
+
   /ts-jest/27.1.5_hqxkrd4qvvy3yhp45ctvqqqjey:
     resolution: {integrity: sha512-Xv6jBQPoBEvBq/5i2TeSG9tt/nqkbpcurrEG1b+2yfBrcJelOZF9Ml6dmyMh7bcW9JyFbRYpR5rxROSlBLTZHA==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -15398,43 +15432,7 @@ packages:
       yargs-parser: 20.2.9
     dev: true
 
-  /ts-jest/27.1.5_ycphgmgat7mqbvnmadx6worcm4:
-    resolution: {integrity: sha512-Xv6jBQPoBEvBq/5i2TeSG9tt/nqkbpcurrEG1b+2yfBrcJelOZF9Ml6dmyMh7bcW9JyFbRYpR5rxROSlBLTZHA==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@types/jest': ^27.0.0
-      babel-jest: '>=27.0.0 <28'
-      esbuild: '*'
-      jest: ^27.0.0
-      typescript: '>=3.8 <5.0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@types/jest':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
-    dependencies:
-      '@babel/core': 7.18.10
-      '@types/jest': 27.5.2
-      babel-jest: 27.5.1_@babel+core@7.18.10
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      jest: 27.5.1
-      jest-util: 27.5.1
-      json5: 2.2.1
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.3.7
-      typescript: 4.8.4
-      yargs-parser: 20.2.9
-    dev: true
-
-  /ts-loader/9.3.1_qqxisngxjbp7lstdk7boexbu3e:
+  /ts-loader/9.3.1_ioost42n2pkm3q6vbnx4ypyu7a:
     resolution: {integrity: sha512-OkyShkcZTsTwyS3Kt7a4rsT/t2qvEVQuKCTg4LJmpj9fhFR7ukGdZwV6Qq3tRUkqcXtfGpPR7+hFKHCG/0d3Lw==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -15445,7 +15443,7 @@ packages:
       enhanced-resolve: 5.10.0
       micromatch: 4.0.5
       semver: 7.3.7
-      typescript: 4.8.4
+      typescript: 4.9.3
       webpack: 5.74.0
     dev: true
 
@@ -15464,7 +15462,7 @@ packages:
       webpack: 5.74.0
     dev: true
 
-  /ts-node/10.9.1_fxotr6iqnckpi76swcl5uzszdi:
+  /ts-node/10.9.1_h4zlp2d3lea7bhgzysddfhpaja:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -15490,7 +15488,7 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 4.8.4
+      typescript: 4.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true
@@ -15503,12 +15501,12 @@ packages:
       minimist: 1.2.6
       strip-bom: 3.0.0
 
-  /tsd/0.24.1:
-    resolution: {integrity: sha512-sD+s81/2aM4RRhimCDttd4xpBNbUFWnoMSHk/o8kC8Ek23jljeRNWjsxFJmOmYLuLTN9swRt1b6iXfUXTcTiIA==}
+  /tsd/0.25.0:
+    resolution: {integrity: sha512-liUlvKtsdr+70XEZP/kkF6U8+Q9URZi4Pw58ih7a9x3kjJblG8rdVgvG62xcvkgRva1q3yWX5qAxfYZuYiC5CA==}
     engines: {node: '>=14.16'}
     hasBin: true
     dependencies:
-      '@tsd/typescript': 4.8.4
+      '@tsd/typescript': 4.9.3
       eslint-formatter-pretty: 4.1.0
       globby: 11.1.0
       meow: 9.0.0
@@ -15542,14 +15540,14 @@ packages:
       typescript: 4.8.2
     dev: false
 
-  /tsutils/3.21.0_typescript@4.8.4:
+  /tsutils/3.21.0_typescript@4.9.3:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.8.4
+      typescript: 4.9.3
     dev: true
 
   /tty-browserify/0.0.0:
@@ -15648,8 +15646,8 @@ packages:
     hasBin: true
     dev: false
 
-  /typescript/4.8.4:
-    resolution: {integrity: sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==}
+  /typescript/4.9.3:
+    resolution: {integrity: sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true


### PR DESCRIPTION
Fix the below error thrown by react `useSyncExternalStore` : 
`Missing getServerSnapshot, which is required for server-rendered content. Will revert to client rendering.`