### PR TITLE
fix: fix computed type

### DIFF
--- a/.changeset/wicked-pillows-fold.md
+++ b/.changeset/wicked-pillows-fold.md
@@ -1,0 +1,5 @@
+---
+'@modern-js-reduck/store': patch
+---
+
+fix: fix computed type

--- a/packages/store/src/__tsd__/computed.tsd.ts
+++ b/packages/store/src/__tsd__/computed.tsd.ts
@@ -44,7 +44,6 @@ describe('test computed', () => {
   test('depend on other models', () => {
     const use = () => store.use(modelA, modelB);
     const [state] = use();
-    // state.str
     expectType<StateA & StateB & { double: number } & { str: string }>(state);
   });
 });

--- a/packages/store/src/types/model.ts
+++ b/packages/store/src/types/model.ts
@@ -134,7 +134,7 @@ export type MountedModel<M extends Model = Model> = {
  * after
  * {
  *   actions: {
- *     a: (state: State) => {};
+ *     a: (payload: string) => {};
  *   }
  * }
  */
@@ -153,8 +153,14 @@ type ModelType = Model;
 // eslint-disable-next-line @typescript-eslint/ban-types
 type ExcludeEmpty<T> = T extends infer P & {} ? P : T;
 
+type NeededUnionType<T extends any[]> = T[number];
+
 type GetModelsState<Models extends Model[]> = ExcludeEmpty<
-  UnionToIntersection<MountedModel<Models[number]>['state']>
+  UnionToIntersection<
+    NeededUnionType<{
+      [Index in keyof Models]: MountedModel<Models[Index]>['state'];
+    }>
+  >
 >;
 
 type GetModelsAction<Models extends Model[]> = Models extends [


### PR DESCRIPTION
If not all models define computed properties,  the state returned by `useModel`  would miss computed properties.

For example:
```
const modelA = model<StateA>('modelA').define({
  state: {
    a: 1,
  },
  computed: {
    double(s) {
      return s.a + 1;
    },
  },
});

const modelB = model<StateB>('modelB').define({
  state: {
    b: '10',
  }
});

const [state] = useModel(modelA, modelB);

state.double;     // would throw ts error

```

This PR would fix this issue.